### PR TITLE
Fix observations

### DIFF
--- a/src/reactive-elements.js
+++ b/src/reactive-elements.js
@@ -33,9 +33,12 @@ function reactiveElements(elementName, ReactComponent, options) {
       if (useShadowDom) self.attachShadow({ mode: 'open' });
 
       const observer = new MutationObserver(() => {
-        ReactDOM.unmountComponentAtNode(getRenderRoot(self, useShadowDom));
         const props = utils.getProps(self);
-        props.children = utils.getChildren(self);
+        // we reuse the `childrenFragment`, rather than creating a new fragment,
+        // as this will cause a mutation in the current React component (because
+        // of the way that DOM nodes must be unique)
+        // but the fragment is a reference, so this is fine to keep a hold of
+        props.children = this.childrenFragment;
         create(self, props);
       });
 
@@ -49,7 +52,9 @@ function reactiveElements(elementName, ReactComponent, options) {
 
     connectedCallback() {
       const props = utils.getProps(this);
-      props.children = utils.getChildren(this);
+      // save a `childrenFragment` to reuse later, on mutations (this is okay
+      // because the fragment is effectively a reference to the children)
+      this.childrenFragment = props.children = utils.getChildren(this);
       let reactElement = create(this, props);
 
       if (reactElement !== null) {


### PR DESCRIPTION
Currently we call `getChildren` on both the creation, and change observation of nodes.

Unfortunately, `getChildren` is actually destructive, as it pulls child elements into a document fragment, and DOM nodes must be unique - causing a mutation of the underlying React container, causing React to get super upset and exploding.

This PR simply does not recreate the document fragments on observed changes. Since the document fragment itself is just a reference to the children, then it should be fine to keep a hold to the same fragment forever (regardless of changes to the underlying children)

The only case this wouldn't be true is if someone were to attempt adding new nodes to the child list outside of React. But I can't see that this would ever be a good idea (rather than using React for this), nor can I see any way of making React not be hugely upset by this (given that you would be effectively changing React's rendered output manually from outside React, which React does get super upset about)